### PR TITLE
refactor(aplayer-jellyfin): 移除 PJAX 支持并优化播放器逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### 功能特点
 - 支持 Jellyfin 音乐库接入
 - 吸底播放器设计，不影响页面浏览体验
-- 支持 PJAX 页面加载，提升交互流畅性
+- 当前版本暂不支持播放器的不间断播放功能。如需实现该效果，请配合使用 `OOW PJAX` 插件。
 
 ### 安装步骤
 1. 下载插件并上传到您的 WordPress 插件目录。
@@ -25,30 +25,3 @@
 ### 注意事项
 - 确保您的 Jellyfin 服务器正在运行，并且可以从 WordPress 服务器访问。
 - 确保您在 Jellyfin 中已经设置了音乐库，并且所选用户有权限访问该库。
-
-## English Description
-
-**APlayer Jellyfin Music Player** is a WordPress plugin that implements a bottom-fixed music player using **APlayer + Jellyfin + localStorage**.
-
-### Features
-- Integration with Jellyfin music library
-- Bottom-fixed player design for non-intrusive browsing experience
-- Support for PJAX page loading to enhance interaction smoothness
-- Bilingual interface (Chinese/English)
-
-### Installation
-1. Download the plugin and upload it to your WordPress plugins directory.
-2. Activate the plugin from the WordPress admin panel.
-3. Go to **Settings > APlayer Jellyfin** to configure your Jellyfin server information.
-4. After saving the settings, you will see the player on the frontend pages.
-
-### Configuration
-- **Jellyfin Server URL**: Enter your Jellyfin server address (e.g., http://localhost:8096)
-- **User ID**: The user ID for the user who will play music in Jellyfin
-- **API Key**: Your Jellyfin API key
-- **Device ID**: Device ID
-- **Music Library ID**: The ID of the music library you want to use
-
-### Notes
-- Ensure your Jellyfin server is running and accessible from the WordPress server.
-- Ensure you have set up a music library in Jellyfin and the selected user has access to it.

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -1,4 +1,3 @@
-
 <div class="wrap">
     <h1>APlayer Jellyfin 设置</h1>
     <form method="post" action="options.php">
@@ -44,6 +43,7 @@
             <ul>
                 <li>确保您的Jellyfin服务器正在运行，并且可以从WordPress服务器访问</li>
                 <li>确保您在Jellyfin中已经设置了音乐库，并且所选用户有权限访问该库</li>
+                <li>当前版本暂不支持播放器的不间断播放功能。如需实现该效果，请配合使用 `OOW PJAX` 插件。</li>
                 <li>如果遇到问题，请检查浏览器控制台和服务器错误日志以获取更多信息</li>
             </ul>
 

--- a/aplayer-jellyfin.php
+++ b/aplayer-jellyfin.php
@@ -26,11 +26,6 @@ function aplayer_jellyfin_enqueue_scripts() {
     wp_enqueue_script('aplayer-player-js', APLAYER_JELLYFIN_URL . 'js/player.js', ['aplayer-script'], null, true);
     wp_enqueue_style('aplayer-custom-style', APLAYER_JELLYFIN_URL . 'css/style.css');
 
-    // PJAX 脚本：使用原生 PJAX 库 替换 jQuery PJAX
-    wp_enqueue_script('pjax', 'https://cdn.jsdelivr.net/npm/pjax@0.2.8/pjax.min.js', [], null, true);
-
-    // 注册一个空的 jmp_ajax 占位，稍后再由配置覆盖
-    wp_localize_script('aplayer-player-js', 'jmp_ajax', []);
 }
 add_action('wp_enqueue_scripts', 'aplayer_jellyfin_enqueue_scripts');
 

--- a/js/player.js
+++ b/js/player.js
@@ -29,23 +29,3 @@ function initializePlayer() {
             });
     }
 }
-
-// PJAX 初始化逻辑
-function initializePjax() {
-    if (typeof Pjax === 'undefined') {
-        console.error('[ERROR] Pjax 未定义，请确保已正确加载 PJAX 库');
-        return;
-    }
-
-    console.info('[INFO] 正在初始化 PJAX...');
-    // 使用原生 PJAX 库的初始化方式
-    new Pjax({
-        elements: "a:not([target='_blank']):not([no-pjax])",  // 避免外链和特殊链接
-        selectors: ["title", "#content"]
-    });
-}
-
-// 在 DOMContentLoaded 事件监听器外部定义完 initializePjax 后再调用它
-document.addEventListener('DOMContentLoaded', function () {
-    initializePjax();
-});


### PR DESCRIPTION
-移除了 aplayer-jellyfin.php 中的 PJAX 相关代码
- 删除了 player.js 中的 PJAX 初始化逻辑
- 更新了 README.md，说明当前版本不支持不间断播放功能
- 在设置页面添加了关于不间断播放的说明